### PR TITLE
Fix for C++20 compiler

### DIFF
--- a/c/build.rs
+++ b/c/build.rs
@@ -114,7 +114,7 @@ fn main() {
 	let mut build_se = cc::Build::new();	// For seperate executable
 	let std_flag = if cfg!(feature = "cef") {
 		if target.contains("msvc") {
-			"/std:c++latest"
+			"/std:c++17"
 		}
 		else {
 			"-std=c++17"


### PR DESCRIPTION
Unfortunately C++20 removed std::result_of which have been used in cef too many times.
This pull help those who have latest MSVC installed to avoid getting error while compiling using cargo.