### PR TITLE
Remove OleAut32.lib

### DIFF
--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -19,6 +19,6 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [build-dependencies]
-bindgen = "^0.69"
+bindgen = "^0.72"
 cc = "^1.0"
 pkg-config = "^0.3"

--- a/c/build.rs
+++ b/c/build.rs
@@ -149,7 +149,6 @@ fn main() {
 	 ************************ */
 	let mut bgbuilder = bindgen::Builder::default()
 		.parse_callbacks(Box::new(BwBindgenCallbacks {}))
-		.clang_arg("-DBW_BINDGEN")
 		.header("src/application.h")
 		.header("src/browser_window.h")
 		.header("src/cookie.h")
@@ -405,5 +404,7 @@ fn main() {
 }
 
 impl bindgen::callbacks::ParseCallbacks for BwBindgenCallbacks {
-	fn item_name(&self, item_name: &str) -> Option<String> { Some("c".to_owned() + item_name) }
+	fn item_name(&self, item_info: bindgen::callbacks::ItemInfo<'_>) -> Option<String> {
+		Some("c".to_owned() + item_info.name)
+	}
 }

--- a/c/src/win32.c
+++ b/c/src/win32.c
@@ -9,7 +9,6 @@
 #include <windows.h>
 
 #pragma comment(lib, "User32.lib")
-#pragma comment(lib, "OleAut32.lib")
 
 #ifndef WC_ERR_INVALID_CHARS
 #define WC_ERR_INVALID_CHARS 0x80


### PR DESCRIPTION
Not 100% confident, but it seems we dont need it. It now allows me to build with `cargo xwin build --target x86_64-pc-windows-msvc` on linux fro windows edge2